### PR TITLE
feat(sensors): Implement Kalman filter for sensor fusion

### DIFF
--- a/src/sensors/Cargo.toml
+++ b/src/sensors/Cargo.toml
@@ -23,7 +23,6 @@ description = "A library for sensor data processing, filtering, and fusion, with
 crate-type = ["lib", "staticlib"]
 
 [dependencies]
-# This section would list external Rust libraries (crates) from crates.io.
-# Based on the analysis of the src files (lib.rs, ffi_bridge.rs, sensor_filters.rs, sensor_fusion.rs),
-# this module does not appear to have any external dependencies. It only uses standard library features
-# and modules defined within its own crate.
+log = "0.4.21"
+thiserror = "1.0.58"
+nalgebra = "0.32.3"

--- a/src/sensors/tk_sensors_fusion.c
+++ b/src/sensors/tk_sensors_fusion.c
@@ -21,7 +21,7 @@ typedef void* FilterHandle;
 
 // FFI declarations for the functions implemented in Rust.
 // In a real build system, this would be in a generated header.
-extern FilterHandle rust_create_complementary_filter(float alpha);
+extern FilterHandle rust_create_kalman_filter(float process_noise, float measurement_noise);
 extern void rust_destroy_filter(FilterHandle handle);
 extern void rust_filter_update(
     FilterHandle handle,
@@ -57,11 +57,11 @@ TK_NODISCARD tk_error_code_t tk_sensor_fusion_create(tk_sensor_fusion_t** out_en
     engine->world_state.motion_state = TK_MOTION_STATE_UNKNOWN;
     engine->world_state.orientation.w = 1.0f; // Identity quaternion
 
-    // Create the Rust-side filter and store its handle.
-    // 0.98 is a common alpha value for complementary filters.
-    engine->rust_filter_handle = rust_create_complementary_filter(0.98f);
+    // Create the Rust-side Kalman filter and store its handle.
+    // These noise values are just defaults and may need tuning.
+    engine->rust_filter_handle = rust_create_kalman_filter(0.01f, 0.1f);
     if (!engine->rust_filter_handle) {
-        LOG_ERROR("Failed to create Rust complementary filter.");
+        LOG_ERROR("Failed to create Rust Kalman filter.");
         free(engine);
         return TK_ERROR_DRIVER_FAILED; // A more specific error would be better
     }


### PR DESCRIPTION
This commit replaces the placeholder complementary filter with a full Kalman filter implementation for sensor fusion.

The changes include:
- Added a `KalmanFilter` implementation in `src/sensors/src/sensor_filters.rs` for 6-DOF orientation tracking.
- Updated the FFI bridge in `src/sensors/src/ffi_bridge.rs` to expose the Kalman filter to the C API.
- Modified the C implementation in `src/sensors/tk_sensors_fusion.c` to use the new Kalman filter.
- Replaced the mock implementation in `src/sensors/src/sensor_fusion.rs` with a complete wrapper around the FFI.
- Added missing dependencies (`nalgebra`, `log`, `thiserror`) to `src/sensors/Cargo.toml`.
- Updated FFI struct definitions in `src/sensors/src/lib.rs`.
- Removed the unused `ComplementaryFilter`.